### PR TITLE
Adding continuous integration with GitLab CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-.gitlab-ci.yml
 builds/

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -6,6 +6,14 @@ services:
 before_script:
   - docker login -u "$CI_REGISTRY_USER" -p "$CI_REGISTRY_PASSWORD" $CI_REGISTRY
 
+
+build-backend:
+  stage: build
+  script:
+    - docker build -f ./backend/Dockerfile -t "$CI_REGISTRY_IMAGE_BACK" ./backend
+    - docker push "$CI_REGISTRY_IMAGE_BACK"
+
+
 build-frontend:
   stage: build
   script:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,34 +4,47 @@ services:
   - docker:dind
 
 before_script:
+  - echo 'Logging to dockerhub.'
   - docker login -u "$CI_REGISTRY_USER" -p "$CI_REGISTRY_PASSWORD" $CI_REGISTRY
 
 
 build-backend:
   stage: build
   script:
+    - echo 'Bulding image for backend.'
     - docker build -f ./backend/Dockerfile -t workshop-ci-entrega-02_backend -t "$CI_REGISTRY_IMAGE_BACK" ./backend
+    - echo 'Pushing backend image to dockerhub.'
     - docker push --all-tags "$CI_REGISTRY_IMAGE_BACK"
+    - echo 'Backend image was successfully built and pushed to dockerhub.'
 
 
 build-frontend:
   stage: build
   script:
+    - echo 'Bulding image for frontend.'
     - docker build -f ./frontend/Dockerfile -t workshop-ci-entrega-02_frontend -t "$CI_REGISTRY_IMAGE_FRONT" ./frontend
+    - echo 'Pushing frontend image to dockerhub.'
     - docker push --all-tags "$CI_REGISTRY_IMAGE_FRONT"
+    - echo 'Frontend image was successfully built and pushed to dockerhub.'
 
 backend-tests:
   image: docker/compose
   stage: test
   script:
+    - echo 'Pulling latest built backend image from dockerhub.'
     - docker pull $CI_REGISTRY_IMAGE_BACK
     - docker tag $CI_REGISTRY_IMAGE_BACK workshop-ci-entrega-02_backend
+    - echo 'Running backend tests.'
     - docker-compose run --entrypoint "npm run unittest" backend
+    - echo 'Backend tests have finished successfully.'
 
 frontend-tests:
   image: docker/compose
   stage: test
   script:
+    - echo 'Pulling latest built frontend image from dockerhub.'
     - docker pull $CI_REGISTRY_IMAGE_FRONT
     - docker tag $CI_REGISTRY_IMAGE_FRONT workshop-ci-entrega-02_frontend
+    - echo 'Running frontend tests.'
     - docker-compose run --entrypoint "npm run test" frontend
+    - echo 'Frontend tests have finished successfully.'

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,14 +10,14 @@ before_script:
 build-backend:
   stage: build
   script:
-    - docker build -f ./backend/Dockerfile -t "$CI_REGISTRY_IMAGE_BACK" ./backend
+    - docker build -f ./backend/Dockerfile  ./backend
     - docker push "$CI_REGISTRY_IMAGE_BACK"
 
 
 build-frontend:
   stage: build
   script:
-    - docker build -f ./frontend/Dockerfile -t "$CI_REGISTRY_IMAGE_FRONT" ./frontend
+    - docker build -f ./frontend/Dockerfile  ./frontend
     - docker push "$CI_REGISTRY_IMAGE_FRONT"
 
 backend-tests:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -19,3 +19,15 @@ build-frontend:
   script:
     - docker build -f ./frontend/Dockerfile -t "$CI_REGISTRY_IMAGE_FRONT" ./frontend
     - docker push "$CI_REGISTRY_IMAGE_FRONT"
+
+backend-tests:
+  image: docker/compose
+  stage: tests
+  script:
+    - docker-compose run --entrypoint "npm run unittest" backend
+
+frontend-tests:
+  image: docker/compose
+  stage: tests
+  script:
+    - docker-compose run --entrypoint "npm run test" frontend

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,0 +1,13 @@
+image: docker
+
+services:
+  - docker:dind
+
+before_script:
+  - docker login -u "$CI_REGISTRY_USER" -p "$CI_REGISTRY_PASSWORD" $CI_REGISTRY
+
+build-frontend:
+  stage: build
+  script:
+    - docker build -f ./frontend/Dockerfile -t "$CI_REGISTRY_IMAGE" ./frontend
+    - docker push "$CI_REGISTRY_IMAGE"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,4 +7,8 @@ before_script:
   - echo "$CI_REGISTRY_USER" 
   - echo "$CI_REGISTRY_PASSWORD" 
   - echo $CI_REGISTRY
+
+build-frontend:
+  stage: build
+  script:
   - echo docker login -u "$CI_REGISTRY_USER" -p "$CI_REGISTRY_PASSWORD" $CI_REGISTRY

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,6 +25,7 @@ backend-tests:
   stage: test
   script:
     - docker pull $CI_REGISTRY_IMAGE_BACK
+    - docker tag $CI_REGISTRY_IMAGE_BACK workshop-ci-entrega-02_backend
     - docker-compose run --entrypoint "npm run unittest" backend
 
 frontend-tests:
@@ -32,4 +33,5 @@ frontend-tests:
   stage: test
   script:
     - docker pull $CI_REGISTRY_IMAGE_FRONT
+    - docker tag $CI_REGISTRY_IMAGE_FRONT workshop-ci-entrega-02_frontend
     - docker-compose run --entrypoint "npm run test" frontend

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -22,12 +22,12 @@ build-frontend:
 
 backend-tests:
   image: docker/compose
-  stage: tests
+  stage: test
   script:
     - docker-compose run --entrypoint "npm run unittest" backend
 
 frontend-tests:
   image: docker/compose
-  stage: tests
+  stage: test
   script:
     - docker-compose run --entrypoint "npm run test" frontend

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -10,14 +10,14 @@ before_script:
 build-backend:
   stage: build
   script:
-    - docker build -f ./backend/Dockerfile  ./backend
+    - docker build -f ./backend/Dockerfile -t workshop-ci-entrega-02_backend -t "$CI_REGISTRY_IMAGE_BACK" ./backend
     - docker push "$CI_REGISTRY_IMAGE_BACK"
 
 
 build-frontend:
   stage: build
   script:
-    - docker build -f ./frontend/Dockerfile  ./frontend
+    - docker build -f ./frontend/Dockerfile -t workshop-ci-entrega-02_frontend -t "$CI_REGISTRY_IMAGE_FRONT" ./frontend
     - docker push "$CI_REGISTRY_IMAGE_FRONT"
 
 backend-tests:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,11 +4,10 @@ services:
   - docker:dind
 
 before_script:
-  - echo "$CI_REGISTRY_USER" 
-  - echo "$CI_REGISTRY_PASSWORD" 
-  - echo $CI_REGISTRY
+  - docker login -u "$CI_REGISTRY_USER" -p "$CI_REGISTRY_PASSWORD" $CI_REGISTRY
 
 build-frontend:
   stage: build
   script:
-  - echo docker login -u "$CI_REGISTRY_USER" -p "$CI_REGISTRY_PASSWORD" $CI_REGISTRY
+    - docker build -f ./frontend/Dockerfile -t "$CI_REGISTRY_IMAGE_FRONT" ./frontend
+    - docker push "$CI_REGISTRY_IMAGE_FRONT"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -24,10 +24,12 @@ backend-tests:
   image: docker/compose
   stage: test
   script:
+    - docker pull $CI_REGISTRY_IMAGE_BACK
     - docker-compose run --entrypoint "npm run unittest" backend
 
 frontend-tests:
   image: docker/compose
   stage: test
   script:
+    - docker pull $CI_REGISTRY_IMAGE_FRONT
     - docker-compose run --entrypoint "npm run test" frontend

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,5 +9,5 @@ before_script:
 build-frontend:
   stage: build
   script:
-    - docker build -f ./frontend/Dockerfile -t "$CI_REGISTRY_IMAGE" ./frontend
-    - docker push "$CI_REGISTRY_IMAGE"
+    - docker build -f ./frontend/Dockerfile -t "$CI_REGISTRY_IMAGE_FRONT" ./frontend
+    - docker push "$CI_REGISTRY_IMAGE_FRONT"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -4,10 +4,7 @@ services:
   - docker:dind
 
 before_script:
-  - docker login -u "$CI_REGISTRY_USER" -p "$CI_REGISTRY_PASSWORD" $CI_REGISTRY
-
-build-frontend:
-  stage: build
-  script:
-    - docker build -f ./frontend/Dockerfile -t "$CI_REGISTRY_IMAGE_FRONT" ./frontend
-    - docker push "$CI_REGISTRY_IMAGE_FRONT"
+  - echo "$CI_REGISTRY_USER" 
+  - echo "$CI_REGISTRY_PASSWORD" 
+  - echo $CI_REGISTRY
+  - echo docker login -u "$CI_REGISTRY_USER" -p "$CI_REGISTRY_PASSWORD" $CI_REGISTRY

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -11,14 +11,14 @@ build-backend:
   stage: build
   script:
     - docker build -f ./backend/Dockerfile -t workshop-ci-entrega-02_backend -t "$CI_REGISTRY_IMAGE_BACK" ./backend
-    - docker push "$CI_REGISTRY_IMAGE_BACK"
+    - docker push --all-tags "$CI_REGISTRY_IMAGE_BACK"
 
 
 build-frontend:
   stage: build
   script:
     - docker build -f ./frontend/Dockerfile -t workshop-ci-entrega-02_frontend -t "$CI_REGISTRY_IMAGE_FRONT" ./frontend
-    - docker push "$CI_REGISTRY_IMAGE_FRONT"
+    - docker push --all-tags "$CI_REGISTRY_IMAGE_FRONT"
 
 backend-tests:
   image: docker/compose


### PR DESCRIPTION
## Motivation
We need CI to automatically build our docker images to dockerhub and to run all our frontend and backend tests. 

## Proposed solution
- [x]  Adding `.gitlab-ci.yml` file to use GitLab-CI
- [x]  Building images for frontend and backend and pushing them to dockerhub
- [x]  Running backend tests
- [x]   Running frontend tests

Dockerhub images are https://hub.docker.com/repository/docker/marcosnbj/workshop-ci-entrega-02-backend and https://hub.docker.com/repository/docker/marcosnbj/workshop-ci-entrega-02-frontend